### PR TITLE
mitigate format-string vulnerability in syslog()

### DIFF
--- a/src/hdapsd.c
+++ b/src/hdapsd.c
@@ -88,7 +88,7 @@ void printlog (FILE *stream, const char *fmt, ...)
 	va_end(ap);
 
 	if (dosyslog)
-	        syslog(LOG_INFO, msg);
+	        syslog(LOG_INFO, "%s", msg);
 	else {
 		now = time((time_t *)NULL);
 		fprintf(stream, "%.24s: %s\n", ctime(&now), msg);


### PR DESCRIPTION
Fixes:
hdapsd fails to build if "-Werror=format-security" flag is used.
...
hdapsd.c:91:3: error: format not a string literal and no format arguments
[-Werror=format-security]

More info at: https://fedoraproject.org/wiki/Format-Security-FAQ

By the way, what about creating a tarball release with latest commits?
