### PR TITLE
log to syslog under systemd

### DIFF
--- a/misc/hdapsd.service.in
+++ b/misc/hdapsd.service.in
@@ -5,7 +5,7 @@ Documentation=man:hdapsd(8)
 [Service]
 SyslogIdentifier=%p
 Nice=-5
-ExecStart=@sbindir@/hdapsd
+ExecStart=@sbindir@/hdapsd --syslog
 Restart=on-abort
 
 [Install]

--- a/misc/hdapsd@.service.in
+++ b/misc/hdapsd@.service.in
@@ -5,5 +5,5 @@ Documentation=man:hdapsd(8)
 [Service]
 SyslogIdentifier=%p(%I)
 Nice=-5
-ExecStart=@sbindir@/hdapsd -d %I
+ExecStart=@sbindir@/hdapsd --syslog -d %I
 Restart=on-abort


### PR DESCRIPTION
this prevents hdapsd to add its own timestamps, which are already provided by
the journal
